### PR TITLE
Fix links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site configuration
 title: "Sean Jain Ellis"
-subtitle: "Developer & Explorer"
-description: "Personal website and blog covering coding, travel, and life adventures."
+subtitle: "Software Development and Life Adventures"
+description: "Personal website and blog covering computing, travel and other life adventures."
 github: "https://github.com/bandarji"
 
 # Theme configuration (using custom theme)

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -72,19 +72,19 @@ body {
   text-transform: uppercase;
   font-size: 0.8rem;
   letter-spacing: 1px;
+  text-shadow: none;
 }
 
 .site-nav a:hover {
   color: var(--terminal-green-bright);
-  text-shadow: 0 0 8px var(--terminal-green-bright);
+  text-shadow: 0 0 3px var(--terminal-green-bright);
 }
 
 /* Main content */
 .site-content {
   max-width: 80ch;
   margin: 0 auto;
-  padding: 2rem 1rem;
-  min-height: calc(100vh - 200px);
+  padding: 1rem;
 }
 
 /* Posts */
@@ -213,13 +213,15 @@ body {
 .post-content a {
   color: var(--terminal-green-bright);
   text-decoration: underline;
-  text-decoration-color: var(--terminal-green-dim);
+  text-decoration-color: var(--terminal-green);
+  text-shadow: none;
+  font-weight: bold;
 }
 
 .post-content a:hover {
   color: var(--terminal-green);
   text-decoration-color: var(--terminal-green);
-  text-shadow: 0 0 8px var(--terminal-green);
+  text-shadow: 0 0 2px var(--terminal-green);
 }
 
 .post-content strong {
@@ -287,7 +289,7 @@ body {
 
 .post-navigation a:hover {
   color: var(--terminal-green-bright);
-  text-shadow: 0 0 8px var(--terminal-green-bright);
+  text-shadow: 0 0 3px var(--terminal-green-bright);
 }
 
 /* Responsive design */
@@ -314,7 +316,8 @@ body {
 /* Home page specific styles */
 .home-content {
   text-align: center;
-  padding: 2rem 0;
+  padding: 1rem 0;
+  margin-bottom: 2rem;
 }
 
 .home-content h1 {
@@ -330,7 +333,7 @@ body {
   font-size: 14px;
   color: var(--terminal-green);
   max-width: 60ch;
-  margin: 0 auto 2rem auto;
+  margin: 0 auto 1rem auto;
 }
 
 /* Category badges */
@@ -361,6 +364,8 @@ body {
   color: var(--terminal-cursor);
   animation: blink 1s infinite;
   font-weight: bold;
+  display: inline-block;
+  margin-left: 0.2rem;
 }
 
 @keyframes blink {


### PR DESCRIPTION
# Issues Fixed

## Fuzzy Hypertext Links
Problem: Links had excessive text shadows making them appear blurry
Fixes Applied:
Removed text shadow from normal link state (text-shadow: none)
Reduced hover text shadow from 8px to 2-3px for subtlety
Made links bold (font-weight: bold) for better visibility
Changed underline color to match text color for consistency
Added text-shadow: none to navigation links

## Blank Space After GitHub Link
Problem: Excessive padding and minimum height causing unwanted space
Fixes Applied:
Reduced main content padding from 2rem 1rem to 1rem
Removed min-height: calc(100vh - 200px) that was forcing extra space
Reduced home content padding from 2rem 0 to 1rem 0
Added margin-bottom: 2rem to home content for proper spacing
Fixed cursor positioning with display: inline-block and proper margins

## Improvements Made

- Links are now crisp and clear - no more fuzzy appearance
- Proper spacing - no excessive blank space
- Better visual hierarchy - links stand out appropriately
- Consistent styling - all links follow the same pattern
- Terminal aesthetic maintained - still looks like a classic terminal
